### PR TITLE
Print usage if called without command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,4 +63,7 @@ case $1 in
         (cd minion-frontend && python manage.py syncdb) || exit 1
         (cd minion-frontend && python manage.py runserver 0.0.0.0:8000) || exit 1
         ;;
+    *)
+        echo "Usage : $0 <clone|develop|run-plugin-service|run-task-engine|run-frontend>"
+        ;;
 esac


### PR DESCRIPTION
Add a default branch for the case block to print usage if no command is provided.
