### PR TITLE
Correcting rabbitmq package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For task distribution and data storage, Minion uses the following services:
 
 If you work on Ubuntu, install the following packages:
 
-    $ sudo apt-get install git build-essential python-virtualenv python-dev rabbitmq mongodb-server
+    $ sudo apt-get install git build-essential python-virtualenv python-dev rabbitmq-server mongodb-server
     $ sudo apt-get install nmap skipfish
 
 If you work on Fedora 18, install the following packages:


### PR DESCRIPTION
$sudo apt-get install rabbitmq
Reading package lists... Done
Building dependency tree  
Reading state information... Done
E: Unable to locate package rabbitmq

But, rabbitmq-server works.
